### PR TITLE
merge Predictions and Games into Tournament, new with sub-navigation

### DIFF
--- a/app/components/navigation_component.html.haml
+++ b/app/components/navigation_component.html.haml
@@ -19,8 +19,7 @@
         .hidden.sm:ml-6.sm:flex.sm:space-x-8
           - if signed_in?
             = render NavigationLinkComponent.new(t('shared.dashboard'), dashboard_path)
-            = render NavigationLinkComponent.new(t('shared.predictions'), predictions_path)
-            = render NavigationLinkComponent.new(t('shared.games'), games_path)
+            = render NavigationLinkComponent.new(t('shared.tournament'), predictions_or_games_path)
             = render NavigationLinkComponent.new(t('shared.teams'), teams_path)
             = render NavigationLinkComponent.new(t('shared.profile'), profile_path)
           - else
@@ -30,8 +29,7 @@
     .pt-2.pb-4.space-y-1
       - if signed_in?
         = render NavigationMobileLinkComponent.new(t('shared.dashboard'), dashboard_path)
-        = render NavigationMobileLinkComponent.new(t('shared.predictions'), predictions_path)
-        = render NavigationMobileLinkComponent.new(t('shared.games'), games_path)
+        = render NavigationMobileLinkComponent.new(t('shared.tournament'), predictions_or_games_path)
         = render NavigationMobileLinkComponent.new(t('shared.teams'), teams_path)
         = render NavigationMobileLinkComponent.new(t('shared.profile'), profile_path)
       - else

--- a/app/components/navigation_component.rb
+++ b/app/components/navigation_component.rb
@@ -6,4 +6,10 @@ class NavigationComponent < ViewComponent::Base
   def signed_in?
     @signed_in
   end
+
+  def predictions_or_games_path
+    return predictions_path if Tournament.before_first_kickoff?
+
+    games_path
+  end
 end

--- a/app/components/tournament_navigation_component.html.haml
+++ b/app/components/tournament_navigation_component.html.haml
@@ -1,0 +1,7 @@
+%h1= t('shared.tournament')
+
+%nav.tournament-navigation.flex.mb-8.text-sm.w-full{ class: 'sm:w-1/2' }
+  = link_to_unless_current t('shared.games'), games_path, class: 'left' do
+    %span.left= t('shared.games')
+  = link_to_unless_current t('shared.predictions'), predictions_path, class: 'right' do
+    %span.right= t('shared.predictions')

--- a/app/components/tournament_navigation_component.rb
+++ b/app/components/tournament_navigation_component.rb
@@ -1,0 +1,5 @@
+class TournamentNavigationComponent < ViewComponent::Base
+  def render?
+    Tournament.tournament_ongoing?
+  end
+end

--- a/app/javascript/styles/app_components.css
+++ b/app/javascript/styles/app_components.css
@@ -4,3 +4,4 @@
 @import "components/navigation.css";
 @import "components/prediction_with_game.css";
 @import "components/invitation_link.css";
+@import "components/tournament_navigation_component.css";

--- a/app/javascript/styles/components/tournament_navigation_component.css
+++ b/app/javascript/styles/components/tournament_navigation_component.css
@@ -1,0 +1,25 @@
+nav.tournament-navigation a,
+nav.tournament-navigation span {
+  @apply w-full border-2 text-center py-2 border-collapse border-pink-300;
+}
+
+nav.tournament-navigation a {
+  @apply bg-pink-100 hover:bg-pink-200 transition;
+}
+
+nav.tournament-navigation span {
+  @apply bg-pink-300;
+}
+
+nav.tournament-navigation .left {
+  @apply rounded-l-lg border-r-0;
+}
+
+nav.tournament-navigation .right {
+  @apply rounded-r-lg border-l-0;
+}
+
+
+
+
+

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -17,6 +17,9 @@ class Game < ApplicationRecord
   validate :final_whistle_is_after_kickoff
   validate :scores_cannot_change_before_kickoff
 
+  scope :ordered_chronologically, -> { order('kickoff_at ASC, uefa_game_id ASC') }
+  scope :ordered_antichronologically, -> { order('kickoff_at DESC, uefa_game_id ASC') }
+
   def final_whistle(reset: false)
     if reset
       self.final_whistle_at = nil

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,0 +1,24 @@
+class Tournament
+  FIRST_GAME = Game.ordered_chronologically.limit(1).first
+  LAST_GAME = Game.ordered_antichronologically.limit(1).first
+
+  def self.before_first_kickoff?
+    FIRST_GAME.kickoff_at.future?
+  end
+
+  def self.after_first_kickoff?
+    FIRST_GAME.kickoff_at.past?
+  end
+
+  def self.before_last_kickoff?
+    LAST_GAME.kickoff_at.future?
+  end
+
+  def self.after_last_kickoff?
+    LAST_GAME.kickoff_at.past?
+  end
+
+  def self.tournament_ongoing?
+    after_first_kickoff? && before_last_kickoff?
+  end
+end

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -1,4 +1,4 @@
-%h1= t('shared.games')
+= render TournamentNavigationComponent.new
 
 .predictions-with-game
   = render partial: 'prediction_with_game', collection: @predictions_with_game

--- a/app/views/predictions/index.html.haml
+++ b/app/views/predictions/index.html.haml
@@ -1,4 +1,4 @@
-%h1= t('shared.predictions')
+= render TournamentNavigationComponent.new
 
 .grid.grid-cols-1.gap-4
   = render PredictionComponent.with_collection(@predictions)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :games, only: %i[index]
-  resources :predictions, only: %i[index]
+  scope :tournament do
+    resources :predictions, only: %i[index]
+    resources :games, only: %i[index]
+  end
+
   resources :teams do
     member do
       get :leave

--- a/test/components/navigation_component_test.rb
+++ b/test/components/navigation_component_test.rb
@@ -6,8 +6,8 @@ class NavigationComponentTest < ViewComponent::TestCase
     render_inline component
     assert_link 'Sign In'
     assert_no_link 'Dashboard'
-    assert_no_link 'Prediction'
-    assert_no_link 'Games'
+    assert_no_link 'Tournament'
+    assert_no_link 'Profile'
   end
 
   test '.render, signed_in' do
@@ -15,7 +15,28 @@ class NavigationComponentTest < ViewComponent::TestCase
     render_inline component
     assert_no_link 'Sign In'
     assert_link 'Dashboard'
-    assert_link 'Prediction'
-    assert_link 'Games'
+    assert_link 'Tournament'
+    assert_link 'Profile'
+  end
+
+  test '.render, signed_in before tournament' do
+    before_tournament do
+      render_inline NavigationComponent.new(signed_in: true)
+      assert_link 'Tournament', href: '/tournament/predictions'
+    end
+  end
+
+  test '.render, signed_in during tournament' do
+    before_game_25 do
+      render_inline NavigationComponent.new(signed_in: true)
+      assert_link 'Tournament', href: '/tournament/games'
+    end
+  end
+
+  test '.render, signed_in after tournament' do
+    after_tournament do
+      render_inline NavigationComponent.new(signed_in: true)
+      assert_link 'Tournament', href: '/tournament/games'
+    end
   end
 end

--- a/test/components/tournament_navigation_component_test.rb
+++ b/test/components/tournament_navigation_component_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class TournamentNavigationComponentTest < ViewComponent::TestCase
+  test '.render, tournament ongoing' do
+    before_game_25 do
+      component = TournamentNavigationComponent.new
+
+      render_inline component
+
+      # We cannot test/simulate scenarios for `link_to_unless_current`,
+      # since we use a controller that is scoped.
+      assert_link 'Predictions', href: '/tournament/predictions'
+      assert_link 'Games', href: '/tournament/games'
+    end
+  end
+
+  test '.render, not render before tournament has started' do
+    before_tournament do
+      render_inline TournamentNavigationComponent.new
+      assert page.text.empty?, 'Should not render before the tournament'
+    end
+  end
+
+  test '.render, not render after tournament has ended' do
+    after_tournament do
+      render_inline TournamentNavigationComponent.new
+      assert page.text.empty?, 'Should not render after the tournament'
+    end
+  end
+end

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -8,8 +8,7 @@ class DashboardTest < ApplicationSystemTestCase
       sign_in_as :diego
 
       within('nav') do
-        assert_link 'Predictions', href: '/predictions', count: 2
-        assert_link 'Games', href: '/games', count: 2
+        assert_link 'Tournament', href: '/tournament/games', count: 2
         assert_link 'Teams', href: '/teams', count: 2
         assert_link 'Profile', href: '/profile', count: 2
       end

--- a/test/system/games_test.rb
+++ b/test/system/games_test.rb
@@ -4,8 +4,7 @@ class GamesTest < ApplicationSystemTestCase
   test 'show upcoming and past games' do
     before_game_25 do
       sign_in_as :diego
-      navigate_to 'Games'
-      assert_selector 'h1', text: 'Games'
+      navigate_to 'Tournament'
       assert_selector '.prediction-with-game', count: 24
     end
   end

--- a/test/system/predictions_test.rb
+++ b/test/system/predictions_test.rb
@@ -8,8 +8,8 @@ class PredictionsTest < ApplicationSystemTestCase
 
     before_game_25 do
       sign_in_as :diego
-      navigate_to 'Predictions'
-      assert_selector 'h1', text: 'Predictions'
+      navigate_to 'Tournament'
+      within('nav.tournament-navigation') { click_on 'Predictions' }
       assert_selector '.prediction', count: 27
       assert_selector "##{dom_id(prediction)}"
     end
@@ -20,8 +20,8 @@ class PredictionsTest < ApplicationSystemTestCase
 
     at_kickoff_of_game_25 do
       sign_in_as :diego
-      navigate_to 'Predictions'
-      assert_selector 'h1', text: 'Predictions'
+      navigate_to 'Tournament'
+      within('nav.tournament-navigation') { click_on 'Predictions' }
       assert_selector '.prediction', count: 25
       assert_selector "##{dom_id(prediction)}", count: 0
     end
@@ -35,7 +35,8 @@ class PredictionsTest < ApplicationSystemTestCase
       using_browser do
         sign_in_as :diego
 
-        navigate_to 'Predictions'
+        navigate_to 'Tournament'
+        within('nav.tournament-navigation') { click_on 'Predictions' }
 
         within("##{dom_id(prediction)}") do
           sleep 0.2
@@ -73,7 +74,7 @@ class PredictionsTest < ApplicationSystemTestCase
     before_tournament do
       sign_in_as :diego
 
-      navigate_to 'Predictions'
+      navigate_to 'Tournament'
 
       within("##{dom_id(prediction)}") do
         assert_selector 'button, a, submit', count: 0

--- a/test/system/tournaments_test.rb
+++ b/test/system/tournaments_test.rb
@@ -1,0 +1,48 @@
+require 'application_system_test_case'
+
+class TournamentsTest < ApplicationSystemTestCase
+  test 'before tournament' do
+    before_tournament do
+      sign_in_as :diego
+      navigate_to 'Tournament'
+
+      assert_selector tournament_navigation_selector, count: 0
+      assert_selector '.prediction'
+    end
+  end
+
+  test 'during tournament' do
+    before_game_25 do
+      sign_in_as :diego
+      navigate_to 'Tournament'
+
+      within(tournament_navigation_selector) do
+        assert_selector 'span', text: 'Games'
+        assert_link 'Predictions', href: '/tournament/predictions'
+        click_on 'Predictions'
+      end
+
+      within(tournament_navigation_selector) do
+        assert_link 'Games', href: '/tournament/games'
+        assert_selector 'span', text: 'Predictions'
+        click_on 'Games'
+      end
+    end
+  end
+
+  test 'after tournament' do
+    after_tournament do
+      sign_in_as :diego
+      navigate_to 'Tournament'
+
+      assert_selector tournament_navigation_selector, count: 0
+      assert_selector '.prediction-with-game'
+    end
+  end
+
+  private
+
+  def tournament_navigation_selector
+    'nav.tournament-navigation'
+  end
+end

--- a/test/time_travelers.rb
+++ b/test/time_travelers.rb
@@ -18,4 +18,8 @@ module TimeTravelers
   def after_game_25(&block)
     travel_to('2021-06-20 17:45:00 UTC', &block)
   end
+
+  def after_tournament(&block)
+    travel_to('2021-07-11 20:00:00 UTC', &block)
+  end
 end


### PR DESCRIPTION
Before this commit the Main Navigation contained "Predictions" and "Games" as two separate items/links.
Since these two things are basically the same, even disjunctive sets of "Games", they have been put into a new Menu Item "Tournament".

Within "Tournament" there's a sub-navigation to toggle between "Games" and "Predictions".

That sub-navigation is only shown during the tournament. Before the tournament it renders the "Predictions" only, after the tournament it renders the "Games" only.