### PR TITLE
improve visual representation of disabled button

### DIFF
--- a/app/components/bet_component.html.haml
+++ b/app/components/bet_component.html.haml
@@ -21,14 +21,14 @@
             .self-center.justify-self-center.text-4xl.my-4.bet--guest-team-score
               = @bet.guest_team_score
             .self-center.justify-self-center.w-full.flex.divide-x-2.divide-pink-50.bet--score-controls--home-team
-              %button.w-full.bg-pink-200.py-2.rounded-l-lg.hover:bg-pink-300.cursor-pointer.transition{ disabled: @bet.home_team_score&.zero?, data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :home, delta: :minus } }
+              %button.bet--score-controls--button.bet--score-controls--left-button{ disabled: @bet.home_team_score&.zero?, data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :home, delta: :minus } }
                 \-
-              %button.w-full.bg-pink-200.py-2.rounded-r-lg.hover:bg-pink-300.cursor-pointer.transition{ data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :home, delta: :plus } }
+              %button.bet--score-controls--button.bet--score-controls--right-button{ data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :home, delta: :plus } }
                 \+
             .self-center.justify-self-center.w-full.flex.divide-x-2.divide-pink-50.bet--score-controls--guest-team
-              %button.w-full.bg-pink-200.py-2.rounded-l-lg.hover:bg-pink-300.cursor-pointer.transition{ disabled: @bet.guest_team_score&.zero?, data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :guest, delta: :minus } }
+              %button.bet--score-controls--button.bet--score-controls--left-button{ disabled: @bet.guest_team_score&.zero?, data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :guest, delta: :minus } }
                 \-
-              %button.w-full.bg-pink-200.py-2.rounded-r-lg.hover:bg-pink-300.cursor-pointer.transition{ data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :guest, delta: :plus } }
+              %button.bet--score-controls--button.bet--score-controls--right-button{ data: { reflex: 'click->Bet#change_score', id: @bet.id, team_score: :guest, delta: :plus } }
                 \+
             .col-span-full.my-4
               %h3.text-2xs.text-center= t('shared.odds')

--- a/app/javascript/styles/app_components.css
+++ b/app/javascript/styles/app_components.css
@@ -8,3 +8,4 @@
 @import "components/invitation_link.css";
 @import "components/tournament_navigation_component.css";
 @import "components/achievement_bar_component.css";
+@import "components/bet_component.css";

--- a/app/javascript/styles/components/bet_component.css
+++ b/app/javascript/styles/components/bet_component.css
@@ -1,0 +1,19 @@
+.bet--score-controls--button {
+  @apply bg-pink-200 w-full py-2;
+}
+
+.bet--score-controls--button:not([disabled]) {
+  @apply hover:bg-pink-300 transition;
+}
+
+.bet--score-controls--button[disabled] {
+  @apply opacity-50 cursor-default;
+}
+
+.bet--score-controls--left-button {
+  @apply rounded-l-lg;
+}
+
+.bet--score-controls--right-button {
+  @apply rounded-r-lg;
+}


### PR DESCRIPTION
If a team score on a bet is 0, the "Minus" button is disabled.
But visually the button still looked the same, as if you could click on it.

This commit improves the styling for these buttons, and applies an `opacity-50` rule if a button is disabled.

![Screenshot 2021-06-01 at 10 52 42](https://user-images.githubusercontent.com/1409672/120295545-83c5f080-c2c7-11eb-97c9-496adfac41b6.png)

Fixes #115 