### PR TITLE
fix bug where all team memberships are reset if user joins any team

### DIFF
--- a/app/services/team_ranking_service.rb
+++ b/app/services/team_ranking_service.rb
@@ -18,7 +18,9 @@ class TeamRankingService
 
   def reset_memberships_ranking_positions_sql
     <<~SQL.squish
-      UPDATE memberships SET ranking_position = NULL
+      UPDATE memberships
+         SET ranking_position = NULL
+       WHERE #{team_id_filter}
     SQL
   end
 

--- a/test/services/team_ranking_service_test.rb
+++ b/test/services/team_ranking_service_test.rb
@@ -14,4 +14,22 @@ class TeamRankingServiceTest < ActiveSupport::TestCase
     assert_equal 2, memberships(:zinedine_global).ranking_position
     assert_equal 3, memberships(:pele_global).ranking_position
   end
+
+  test '.call! with single team_id' do
+    campeones_team = teams(:campeones)
+    campeones_team.memberships.update_all(ranking_position: nil)
+
+    diego_global = memberships(:diego_global)
+    diego_global.update_column(:ranking_position, 999)
+    diego_campeones = memberships(:diego_campeones)
+
+    assert_no_changes -> { diego_global.reload.ranking_position },
+                      'Ranking position for other than campeones team membership should NOT change' do
+      assert_changes -> { diego_campeones.reload.ranking_position },
+                     'Ranking position in campeones team membership should change',
+                     to: 1 do
+        TeamRankingService.new(team_ids: campeones_team.id).call!
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a user joins a team, the ranking positions for its memberships have to be recalculated.
Therefore TeamRankingService takes an argument to run the update only within the specific scope of given team.

Before this commit, the service did not apply that scope when resetting all ranking positions.
The second step, re-calculating and updating the ranking positions uses the scope, but all other ranking positions remain reset.

This commit adds the scope to the reset step, thus fixes the bug.