### PR TITLE
remove profile menu

### DIFF
--- a/app/components/navigation_component.html.haml
+++ b/app/components/navigation_component.html.haml
@@ -22,6 +22,7 @@
             = render NavigationLinkComponent.new(t('shared.dashboard'), dashboard_path)
             = render NavigationLinkComponent.new(t('shared.tournament'), bets_or_games_path)
             = render NavigationLinkComponent.new(t('shared.teams'), teams_path)
+            = render NavigationLinkComponent.new(t('shared.profile'), profile_path)
             - if admin?
               = render NavigationLinkComponent.new(t('shared.admin'), admin_games_path)
           - else
@@ -30,16 +31,11 @@
 
       - if signed_in?
         #profile-menu.absolute.inset-y-0.right-0.flex.items-center.pr-2.sm:static.sm:inset-auto.sm:ml-6.sm:pr-0
-          .ml-3.relative
-            %div
-              %button#user-menu.bg-white.rounded-full.flex.text-sm.focus:outline-none.focus:ring-2.focus:ring-offset-2.focus:ring-pink-500{'aria-expanded': 'false', 'aria-haspopup': 'true', type: 'button', data: { action: 'click->navigation#toggleProfileMenu', 'navigation-target': 'profileMenuToggler' }}
-                %span.sr-only= t('.open_profile_menu')
-                %svg.w-8.h-8.text-pink-700.hover:text-pink-500.transition{fill: 'none', stroke: 'currentColor', viewbox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg'}
-                  %path{d: 'M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'round', 'stroke-width' => '2'}
-            .hidden.origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg.py-1.bg-white.ring-1.ring-black.ring-opacity-5.focus:outline-none{'aria-labelledby': 'user-menu', 'aria-orientation': 'vertical', role: 'menu', data: { 'navigation-target': 'profileMenu' } }
-              = link_to t('shared.profile'), profile_path, class: 'block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100', role: 'menuitem'
-              = link_to t('shared.sign_out'), destroy_user_session_path, method: :delete, class: 'block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100', role: 'menuitem'
-      - else
+          = link_to destroy_user_session_path, method: :delete, class: 'text-center inline-flex items-center px-2 py-2 text-gray-400 hover:text-gray-900 transition' do
+            %svg.h-4.w-4{fill: "none", stroke: "currentColor", viewbox: "0 0 24 24", xmlns: "http://www.w3.org/2000/svg"}
+              %path{d: "M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1", "stroke-linecap" => "round", "stroke-linejoin" => "round", "stroke-width" => "2"}
+            .sr-only= t('shared.sign_out')
+      - else signed_in?
         #profile-menu.absolute.inset-y-0.right-0.flex.items-center.pr-2.sm:static.sm:inset-auto.sm:ml-6.sm:pr-0
           .ml-3.relative.text-sm
             = link_to other_locale_abbreviation, { locale: other_locale_key }, class: 'shy-link'
@@ -50,6 +46,7 @@
         = render NavigationMobileLinkComponent.new(t('shared.dashboard'), dashboard_path)
         = render NavigationMobileLinkComponent.new(t('shared.tournament'), bets_or_games_path)
         = render NavigationMobileLinkComponent.new(t('shared.teams'), teams_path)
+        = render NavigationMobileLinkComponent.new(t('shared.profile'), profile_path)
         - if admin?
           = render NavigationMobileLinkComponent.new(t('shared.admin'), admin_games_path)
       - else

--- a/app/javascript/controllers/navigation_controller.js
+++ b/app/javascript/controllers/navigation_controller.js
@@ -5,14 +5,11 @@ export default class extends Controller {
     "mobileMenu",
     "mobileMenuToggler",
     "mobileMenuIconClosed",
-    "mobileMenuIconOpened",
-    "profileMenu",
-    "profileMenuToggler"
+    "mobileMenuIconOpened"
   ];
 
   connect() {
     this.renderMobileMenu();
-    this.renderProfileMenu();
   }
 
   renderMobileMenu() {
@@ -27,55 +24,24 @@ export default class extends Controller {
     }
   }
 
-  renderProfileMenu() {
-    if(this.hasProfileMenuTarget) {
-      if (this.displayProfileMenu()) {
-        this.profileMenuTarget.classList.remove('hidden');
-      } else {
-        this.profileMenuTarget.classList.add('hidden');
-      }
-    }
-  }
-
   toggleMobileMenu() {
     this.switchMobileMenuAriaExpanded();
     this.renderMobileMenu();
-  }
-
-  toggleProfileMenu() {
-    this.switchProfileMenuAriaExpanded();
-    this.renderProfileMenu();
   }
 
   switchMobileMenuAriaExpanded() {
     this.setMobileMenuAriaExpanded(!this.displayMobileMenu());
   };
 
-  switchProfileMenuAriaExpanded() {
-    this.setProfileMenuAriaExpanded(!this.displayProfileMenu());
-  };
-
   displayMobileMenu() {
     return (this.getMobileMenuAriaExpanded() === 'true');
-  }
-
-  displayProfileMenu() {
-    return (this.getProfileMenuAriaExpanded() === 'true');
   }
 
   setMobileMenuAriaExpanded(boolean) {
     this.mobileMenuTogglerTarget.setAttribute('aria-expanded', String(boolean));
   }
 
-  setProfileMenuAriaExpanded(boolean) {
-    this.profileMenuTogglerTarget.setAttribute('aria-expanded', String(boolean));
-  }
-
   getMobileMenuAriaExpanded() {
     return this.mobileMenuTogglerTarget.getAttribute('aria-expanded');
-  }
-
-  getProfileMenuAriaExpanded() {
-    return this.profileMenuTogglerTarget.getAttribute('aria-expanded');
   }
 }

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -371,7 +371,6 @@ de-CH:
       full: Englisch
   navigation_component:
     open_main_menu: Hauptmenu öffnen
-    open_profile_menu: Profilmenu öffnen
   number:
     currency:
       format:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,7 +371,6 @@ en:
       full: English
   navigation_component:
     open_main_menu: Open main menu
-    open_profile_menu: Open profile menu
   number:
     currency:
       format:

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -19,15 +19,10 @@ class ProfileTest < ApplicationSystemTestCase
     end
   end
 
-  test 'sees profile through profile menu' do
+  test 'sees profile through menu' do
     using_browser do
       sign_in_as :diego
-
-      within('#profile-menu') do
-        click_button
-        click_on 'Profile'
-      end
-
+      navigate_to 'Profile'
       assert_selector 'h1', text: 'PROFILE'
       assert_field 'Email', disabled: true
       assert_link 'Dashboard', href: '/dashboard'
@@ -53,7 +48,7 @@ class ProfileTest < ApplicationSystemTestCase
   test 'deletes the account' do
     using_browser do
       sign_in_as :diego
-      click_on 'Profile'
+      navigate_to 'Profile'
       click_on 'Delete my account'
       click_on 'Confirm deletion'
 

--- a/test/system/teams_test.rb
+++ b/test/system/teams_test.rb
@@ -169,6 +169,7 @@ class TeamsTest < ApplicationSystemTestCase
 
         within('section#admin') do
           assert_changes -> { find_field('Invitation link').value } do
+            sleep 0.1
             click_on 'Refresh invitation link'
           end
         end


### PR DESCRIPTION
Some users reported, that it was not clear enough that one can click on the profile icon on the top right.

That profile icon opens a menu that contained a link to "Profile" and one to "Sign out".

This commit moves the link to "Profile" to the regular navigation menu, and places a "Sign out" icon where the "Profile icon" used to be.



| before | after |
|-|-|
| ![Screen Shot 2021-06-13 at 13 21 55](https://user-images.githubusercontent.com/1409672/121805198-722b0400-cc4a-11eb-964b-125a0ef2f0c2.png) | ![Screen Shot 2021-06-13 at 13 21 23](https://user-images.githubusercontent.com/1409672/121805206-76efb800-cc4a-11eb-9a47-aca7d4ac9890.png) |

