### PR TITLE
add user total points history

### DIFF
--- a/app/components/team_membership_row_component.html.haml
+++ b/app/components/team_membership_row_component.html.haml
@@ -1,9 +1,26 @@
-%tr.text-sm{ class: bg_color_class }
-  - if render_ranking_and_points?
-    %td.ranking-position.px-3.py-4.whitespace-nowrap.text-gray-900.text-center
-      = @team_membership_row.ranking_position
-    %td.total-points.px-3.py-4.whitespace-nowrap.text-gray-900.text-center
-      .inline-flex.items-center.px-2.5.py-0.5.rounded-full.font-medium.bg-pink-100.text-pink-800
-        = team_membership_user.total_points
-  %td.nickname-with-emoji.px-3.py-4.whitespace-nowrap.text-gray-900
-    = render NicknameComponent.new(user: team_membership_user, rooting_for_team: true)
+.w-full.text-sm.border-t.border-pink-200.team-membership-row{ data: { controller: 'user-total-points-history', 'user-total-points-history-opened-value': false, 'user-total-points-history-loaded-value': false, 'user-total-points-history-user-id': @team_membership_row.user_id } }
+  .flex.items-center{ class: bg_color_class }
+    - if render_ranking_and_points?
+      .ranking-position.px-3.py-4.whitespace-nowrap.text-gray-900.text-center{ class: 'w-1/6' }
+        = @team_membership_row.ranking_position
+      .total-points.px-3.py-4.whitespace-nowrap.text-gray-900.text-center{ class: 'w-1/6' }
+        .inline-flex.items-center.px-2.5.py-0.5.rounded-full.font-medium.bg-pink-100.text-pink-800
+          = team_membership_user.total_points
+    .nickname-with-emoji.px-3.py-4.whitespace-nowrap.text-gray-900{ class: 'w-4/6' }
+      .flex.items-center
+        .w-full
+          = render NicknameComponent.new(user: team_membership_user, rooting_for_team: true)
+        - if render_user_total_points_history?
+          .flex-shrink-0
+            .user-total-points-history-navigation.flex.items-center
+              %button.w-full{ data: { action: 'click->user-total-points-history#toggleHistory' }, 'aria-controls': 'game-stats' }
+                / chevron UP
+                %svg.mx-auto.h-5.w-5.text-gray-500{fill: 'none', stroke: 'currentColor', viewbox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg', 'data-user-total-points-history-target': 'closeButton' }
+                  %path{d: 'M5 15l7-7 7 7', 'stroke-linecap': 'round', 'stroke-linejoin': 'round', 'stroke-width': '2'}
+                / chevron DOWN
+                %svg.hidden.mx-auto.h-5.w-5.text-gray-500.hover:text-black.transition{fill: 'none', stroke: 'currentColor', viewbox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg', 'data-user-total-points-history-target': 'openButton' }
+                  %path{d: 'M19 9l-7 7-7-7', 'stroke-linecap': 'round', 'stroke-linejoin': 'round', 'stroke-width': '2'}
+
+  - if render_user_total_points_history?
+    .flex.items-center{ 'data-user-total-points-history-target': 'content' }
+      .w-full.p-3{ id: "user-#{@team_membership_row.user_id}-total-points-history" }

--- a/app/components/team_membership_row_component.rb
+++ b/app/components/team_membership_row_component.rb
@@ -16,6 +16,10 @@ class TeamMembershipRowComponent < ViewComponent::Base
     Tournament.after_first_kickoff?
   end
 
+  def render_user_total_points_history?
+    render_ranking_and_points? && !@team_membership_row.team.global?
+  end
+
   private
 
   def team_membership_of_user?

--- a/app/components/team_memberships_component.html.haml
+++ b/app/components/team_memberships_component.html.haml
@@ -5,20 +5,12 @@
     .text-right
       = raw pagy_nav(@pagy)
 
-  .flex.flex-col
-    .-my-2.overflow-x-auto.sm:-mx-6.lg:-mx-8
-      .py-2.align-middle.inline-block.min-w-full.sm:px-6.lg:px-8
-        .overflow-hidden.border-2.border-pink-200.rounded-xl
-          %table.min-w-full.divide-y.divide-pink-100.team-memberships
-            %thead.bg-pink-200
-              %tr.border-0.border-b-1
-                - if render_ranking_and_points?
-                  %th.px-3.py-3.text-center.text-xs.font-medium.text-pink-700.uppercase.tracking-wider{ scope: 'col', class: 'w-1/12' }
-                    = t('activerecord.attributes.membership.ranking_position_short')
-                  %th.px-3.py-3.text-center.text-xs.font-medium.text-pink-700.uppercase.tracking-wider{ scope: 'col', class: 'w-1/12' }
-                    = t('activerecord.attributes.user.total_points_short')
-                %th.px-3.py-3.text-left.text-xs.font-medium.text-pink-700.uppercase.tracking-wider{ scope: 'col', class: 'w-auto' }
-                  = t('activerecord.attributes.user.nickname')
+  .flex.table.border-2.border-pink-200.rounded-xl.overflow-hidden.team-memberships
+    .flex.table-header.bg-pink-200.text-pink-700
+      - if Tournament.after_first_kickoff?
+        .text-center.px-3.py-4{ class: 'w-1/6' }= t('activerecord.attributes.membership.ranking_position_short')
+        .text-center.px-3.py-4{ class: 'w-1/6' }= t('activerecord.attributes.user.total_points_short')
+      .px-3.py-4{ class: 'w-4/6' }= t('activerecord.attributes.user.nickname')
 
-            %tbody.bg-white.divide-y.divide-pink-100
-              = render TeamMembershipRowComponent.with_collection(@records, user: user)
+    .flex.flex-wrap.table-body
+      = render TeamMembershipRowComponent.with_collection(@records, user: user)

--- a/app/components/user_total_points_history_component.html.haml
+++ b/app/components/user_total_points_history_component.html.haml
@@ -1,0 +1,10 @@
+.user-total-points-history-table
+  .grid.grid-cols-3.user-total-points-history-table--header-row
+    .w-full.text-xs.text-pink-500= Game.model_name.human
+    .w-full.text-xs.text-pink-500.text-center= t('.final_score')
+    .w-full.text-xs.text-pink-500.text-right= t('shared.points')
+  - users_bets_with_games.each do |bet|
+    .grid.grid-cols-3.user-total-points-history-table--body-row
+      .w-full= bet.game.decorate.display_teams_short
+      .w-full.text-center= bet.game.decorate.display_scores_short
+      .w-full.text-right= bet.total_points

--- a/app/components/user_total_points_history_component.rb
+++ b/app/components/user_total_points_history_component.rb
@@ -1,0 +1,9 @@
+class UserTotalPointsHistoryComponent < ViewComponent::Base
+  def initialize(user:)
+    @user = user
+  end
+
+  def users_bets_with_games
+    @users_bets_with_games ||= @user.bets.with_game.of_ended_games.ordered_antichronologically
+  end
+end

--- a/app/javascript/controllers/user_total_points_history_controller.js
+++ b/app/javascript/controllers/user_total_points_history_controller.js
@@ -1,0 +1,27 @@
+import ApplicationController from './application_controller.js'
+
+export default class extends ApplicationController {
+  static targets = ['content', 'openButton', 'closeButton'];
+  static values = { opened: Boolean, loaded: Boolean, userId: Number }
+
+  connect() {
+    super.connect();
+    this.render();
+  }
+
+  render() {
+    this.contentTarget.classList.toggle('hidden', !this.openedValue);
+    this.openButtonTarget.classList.toggle('hidden', this.openedValue);
+    this.closeButtonTarget.classList.toggle('hidden', !this.openedValue);
+  }
+
+  toggleHistory() {
+    if(!this.loadedValue) {
+      this.stimulate('UserTotalPointsHistoryReflex#display', { resolveLate: true }).then(() => {
+        this.loadedValue = true;
+      });
+    }
+    this.openedValue = !this.openedValue;
+    this.render();
+  }
+}

--- a/app/models/bet.rb
+++ b/app/models/bet.rb
@@ -17,6 +17,7 @@ class Bet < ApplicationRecord
   scope :ordered_antichronologically, -> { includes(:game).order('games.kickoff_at DESC, games.uefa_game_id ASC') }
   scope :kickoff_future, -> { joins(:game).where('games.kickoff_at > :datetime', datetime: Time.zone.now) }
   scope :kickoff_past, -> { joins(:game).where('games.kickoff_at <= :datetime', datetime: Time.zone.now) }
+  scope :of_ended_games, -> { joins(:game).where.not(games: { final_whistle_at: nil }) }
   scope :bet_ready, -> do
     joins(:game).where('games.kickoff_at > :time', time: Time.zone.now)
                 .where('games.home_team_name IS NOT NULL AND games.guest_team_name IS NOT NULL')

--- a/app/reflexes/user_total_points_history_reflex.rb
+++ b/app/reflexes/user_total_points_history_reflex.rb
@@ -1,0 +1,10 @@
+class UserTotalPointsHistoryReflex < ApplicationReflex
+  def display
+    morph "#user-#{find_user.id}-total-points-history",
+          render(UserTotalPointsHistoryComponent.new(user: find_user), layout: false)
+  end
+
+  def find_user
+    @find_user ||= User.find(element.dataset[:user_total_points_history_user_id])
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -103,6 +103,7 @@ search:
 
 ## Consider these keys used:
 ignore_unused:
+  - "activemodel.models.*"
   - "activerecord.attributes.*.*"
   - "activerecord.errors.messages.*"
   - "date.*"

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -36,6 +36,9 @@ de-CH:
     you_scored_x_points:
       one: Du hast 1 Punkt gewonnen
       other: Du hast %{count} Punkte gewonnen
+  activemodel:
+    models:
+      game: Spiel
   activerecord:
     attributes:
       game:
@@ -557,3 +560,5 @@ de-CH:
       long: "%A, %d. %B %Y, %H:%M Uhr"
       short: "%d. %B, %H:%M Uhr"
     pm: nachmittags
+  user_total_points_history_component:
+    final_score: Endstand

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
     you_scored_x_points:
       one: You scored 1 point
       other: You scored %{count} points
+  activemodel:
+    models:
+      game: Game
   activerecord:
     attributes:
       game:
@@ -549,3 +552,5 @@ en:
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
     pm: pm
+  user_total_points_history_component:
+    final_score: Final score

--- a/test/components/team_membership_row_component_test.rb
+++ b/test/components/team_membership_row_component_test.rb
@@ -20,11 +20,9 @@ class TeamMembershipRowComponentTest < ViewComponent::TestCase
 
       render_inline(component)
 
-      page.all('td').tap do |td|
-        assert_equal '1', td[0].text.strip
-        assert_equal '152', td[1].text.strip
-        assert_selector '.nickname', text: 'digi'
-      end
+      assert_selector '.ranking-position', text: '1'
+      assert_selector '.total-points', text: '152'
+      assert_selector '.nickname', text: 'digi'
     end
   end
 end

--- a/test/components/team_memberships_component_test.rb
+++ b/test/components/team_memberships_component_test.rb
@@ -5,7 +5,7 @@ class TeamMembershipsComponentTest < ViewComponent::TestCase
     component = TeamMembershipsComponent.new(team: teams(:global), params: {}, user: users(:diego))
     render_inline(component)
     assert_selector 'nav.pagination', count: 0
-    assert_selector 'table.team-memberships'
+    assert_selector '.team-memberships'
   end
 
   test '.render with pagination' do
@@ -22,15 +22,41 @@ class TeamMembershipsComponentTest < ViewComponent::TestCase
     before_tournament do
       component = TeamMembershipsComponent.new(team: teams(:global), params: {}, user: users(:diego))
       render_inline(component)
-      assert_selector 'th', count: 1
+      assert_selector '.table-header', count: 1
     end
   end
 
-  test '.render, in game 1' do
+  test '.render, different elements before and after tournament starts' do
+    before_tournament do
+      component = TeamMembershipsComponent.new(team: teams(:campeones), params: {}, user: users(:diego))
+      render_inline(component)
+      assert_table_header_columns count: 1
+      assert_user_total_points_history_navigation count: 0
+    end
+
+    in_game_1 do
+      component = TeamMembershipsComponent.new(team: teams(:campeones), params: {}, user: users(:diego))
+      render_inline(component)
+      assert_table_header_columns count: 3
+      assert_user_total_points_history_navigation
+    end
+  end
+
+  test '.render, does not show user total points in global team' do
     in_game_1 do
       component = TeamMembershipsComponent.new(team: teams(:global), params: {}, user: users(:diego))
       render_inline(component)
-      assert_selector 'th', count: 3
+      assert_user_total_points_history_navigation count: 0
     end
+  end
+
+  private
+
+  def assert_table_header_columns(options = {})
+    assert_selector '.table-header > *', options
+  end
+
+  def assert_user_total_points_history_navigation(options = {})
+    assert_selector '.table-body .user-total-points-history-navigation', options
   end
 end

--- a/test/components/user_total_points_history_component_test.rb
+++ b/test/components/user_total_points_history_component_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class UserTotalPointsHistoryComponentTest < ViewComponent::TestCase
+  test '#render' do
+    before_game_25 do
+      component = UserTotalPointsHistoryComponent.new(user: users(:diego))
+      render_inline(component)
+
+      assert_selector '.user-total-points-history-table', count: 1
+      assert_selector '.user-total-points-history-table--header-row', count: 1
+      assert_selector '.user-total-points-history-table--body-row', count: 24
+    end
+  end
+end

--- a/test/models/bet_test.rb
+++ b/test/models/bet_test.rb
@@ -45,6 +45,15 @@ class BetTest < ActiveSupport::TestCase
     end
   end
 
+  test '.of_ended_games' do
+    user = users(:diego)
+    before_game_25 do
+      assert_difference -> { Bet.of_user(user).of_ended_games.count }, -1 do
+        games(:game_24).final_whistle(reset: true)
+      end
+    end
+  end
+
   test '#update_game_bets_count after save' do
     game = games(:game_25)
     bet = bets(:diego_game_25) # bets 1:2

--- a/test/system/teams_test.rb
+++ b/test/system/teams_test.rb
@@ -46,11 +46,11 @@ class TeamsTest < ApplicationSystemTestCase
       assert_selector 'h2', text: 'Members'
       assert_selector 'h2', text: 'Admin'
 
-      within 'table.team-memberships' do
-        assert_selector 'td.ranking-position', count: 0
-        assert_selector 'td.total-points', count: 0
-        assert_selector 'td.nickname-with-emoji', text: 'digi'
-        assert_selector 'td.nickname-with-emoji', text: 'pele'
+      within '.team-memberships' do
+        assert_selector '.ranking-position', count: 0
+        assert_selector '.total-points', count: 0
+        assert_selector '.nickname-with-emoji', text: 'digi'
+        assert_selector '.nickname-with-emoji', text: 'pele'
       end
     end
   end
@@ -66,11 +66,38 @@ class TeamsTest < ApplicationSystemTestCase
 
       assert_selector 'h2', text: 'Your ranking in this team'
 
-      within 'table.team-memberships' do
-        assert_selector 'td.ranking-position', text: '1'
-        assert_selector 'td.total-points', text: '152'
-        assert_selector 'td.nickname-with-emoji', text: 'digi'
+      within '.team-memberships' do
+        assert_selector '.ranking-position', text: '1'
+        assert_selector '.total-points', text: '152'
+        assert_selector '.nickname-with-emoji', text: 'digi'
       end
+    end
+  end
+
+  test 'shows user total points history for team mates' do
+    before_game_25 do
+      using_browser do
+        sign_in_as :diego
+        navigate_to 'Teams'
+        click_on 'Campeones'
+
+        within '.team-membership-row:first-of-type' do
+          assert_selector '.user-total-points-history-navigation'
+          find('button').click
+          assert_selector '.user-total-points-history-table', count: 1
+          find('button').click
+          assert_selector '.user-total-points-history-table', count: 0
+        end
+      end
+    end
+  end
+
+  test 'does not show user total points history in global team' do
+    before_game_25 do
+      sign_in_as :diego
+      navigate_to 'Teams'
+      click_on 'Global'
+      assert_selector '.user-total-points-history-navigation', count: 0
     end
   end
 


### PR DESCRIPTION
This adds "User total points history" tables to the team page. These tables show a user's points history of all past and ended games.

It does not show the actual bet of a user, just the points that they earned.

These tables are not available in the "Global" team

| screenshot | |
|-|-|
| ![Screen Shot 2021-06-16 at 13 11 09](https://user-images.githubusercontent.com/1409672/122209072-620e6100-cea4-11eb-8b7f-4d306964a36b.png) | |
