### PR TITLE
introduce FinalRankingComponent to be displayed after the tournament

### DIFF
--- a/app/components/current_ranking_component.html.haml
+++ b/app/components/current_ranking_component.html.haml
@@ -1,0 +1,11 @@
+%section#current-ranking
+  .border-2.border-blue-300.rounded-xl.overflow-auto.shadow-xl
+    .grid.grid-cols-2.justify-items-center
+      .bg-blue-300.border.border-blue-300.py-4.w-full.text-center.text-sm
+        = t('shared.points')
+      .bg-blue-300.py-4.w-full.text-center.text-sm
+        = t('shared.global_ranking')
+      .points.text-3xl.py-8= total_points
+      .global-ranking.text-3xl.py-8= global_ranking_position
+      .col-span-full.text-center.mt-2.mb-4
+        = link_to t('shared.global_ranking'), team_path(:global), class: 'inline-flex items-center justify-center px-6 py-2 border border-transparent font-medium rounded-md text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 text-sm'

--- a/app/components/current_ranking_component.rb
+++ b/app/components/current_ranking_component.rb
@@ -1,0 +1,17 @@
+class CurrentRankingComponent < ViewComponent::Base
+  def initialize(user)
+    @user = user
+  end
+
+  def render?
+    !Tournament.after_last_final_whistle?
+  end
+
+  def total_points
+    @total_points ||= @user.total_points
+  end
+
+  def global_ranking_position
+    @global_ranking_position ||= @user.membership_for(Team.global)&.ranking_position
+  end
+end

--- a/app/components/dashboard_ranking_component.html.haml
+++ b/app/components/dashboard_ranking_component.html.haml
@@ -1,11 +1,4 @@
-%section#ranking
-  .border-2.border-blue-300.rounded-xl.overflow-auto.shadow-xl
-    .grid.grid-cols-2.justify-items-center
-      .bg-blue-300.border.border-blue-300.py-4.w-full.text-center.text-sm
-        = t('shared.points')
-      .bg-blue-300.py-4.w-full.text-center.text-sm
-        = t('shared.global_ranking')
-      .points.text-3xl.py-8= total_points
-      .global-ranking.text-3xl.py-8= global_ranking_position
-      .col-span-full.text-center.mt-2.mb-4
-        = link_to t('shared.global_ranking'), team_path(:global), class: 'inline-flex items-center justify-center px-6 py-2 border border-transparent font-medium rounded-md text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 text-sm'
+- if display_final_ranking?
+  = render FinalRankingComponent.new(@user)
+- else
+  = render CurrentRankingComponent.new(@user)

--- a/app/components/dashboard_ranking_component.rb
+++ b/app/components/dashboard_ranking_component.rb
@@ -7,11 +7,7 @@ class DashboardRankingComponent < ViewComponent::Base
     Tournament.after_first_kickoff?
   end
 
-  def total_points
-    @total_points ||= @user.total_points
-  end
-
-  def global_ranking_position
-    @global_ranking_position ||= @user.membership_for(Team.global)&.ranking_position
+  def display_final_ranking?
+    Tournament.after_last_final_whistle?
   end
 end

--- a/app/components/final_ranking_component.html.haml
+++ b/app/components/final_ranking_component.html.haml
@@ -1,0 +1,20 @@
+%section#final-ranking
+  .border-2.border-green-300.rounded-xl.overflow-auto.shadow-xl
+    .grid.grid-cols-1.justify-items-center
+      .bg-green-300.py-4.w-full.text-center.text-sm
+        = t('shared.your_final_global_ranking')
+      .global-ranking.text-7xl.py-8.text-center
+        = global_ranking_position
+        .text-xs.mt-2.text-gray-600
+          = "(#{t('shared.n_points', count: total_points)})"
+      .text-center.border-t.m-4.mt-0.pt-8.mb-6
+        .text-gray-700
+          = t('.congratulations_to_our_global_winners', count: global_winners.count)
+        .text-center.mt-4.text-3xl 👏👏👏
+        %ul.text-2xl.my-10
+          - global_winners.each do |global_winner|
+            %li.my-3= render NicknameComponent.new(user: global_winner, rooting_for_team: true)
+        .my-4.text-gray-700
+          = t('.they_deserve_title_html', count: global_winners.count)
+      .text-center.mt-2.mb-4
+        = link_to t('shared.global_ranking'), team_path(:global), class: 'inline-flex items-center justify-center px-6 py-2 border border-transparent font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 text-sm'

--- a/app/components/final_ranking_component.rb
+++ b/app/components/final_ranking_component.rb
@@ -1,0 +1,9 @@
+class FinalRankingComponent < CurrentRankingComponent
+  def render?
+    Tournament.after_last_final_whistle?
+  end
+
+  def global_winners
+    @global_winners ||= User.where(id: Team.global.memberships.ranked_first.select(:user_id))
+  end
+end

--- a/app/components/nickname_component.html.haml
+++ b/app/components/nickname_component.html.haml
@@ -1,4 +1,4 @@
-.flex.items-start
+.inline-flex.items-start
   = nickname
   - if titles?
     .titles.ml-2.flex

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,6 +12,7 @@ class Membership < ApplicationRecord
   scope :ordered_by_global_and_team_name, -> {
     with_teams.order(Arel.sql("CASE WHEN teams.tippkick_id = 'global' THEN 1 ELSE 2 END, teams.name"))
   }
+  scope :ranked_first, -> { where(ranking_position: 1) }
 
   after_destroy :update_stats
   after_save :update_stats

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,25 +1,34 @@
 class Tournament
-  FIRST_GAME = Game.ordered_chronologically.limit(1).first
-  LAST_GAME = Game.ordered_antichronologically.limit(1).first
+  def self.first_game
+    Game.find_by(uefa_game_id: '1')
+  end
+
+  def self.last_game
+    Game.find_by(uefa_game_id: '51')
+  end
 
   def self.before_first_kickoff?
-    FIRST_GAME.kickoff_at.future?
+    first_game.kickoff_at.future?
   end
 
   def self.after_first_kickoff?
-    FIRST_GAME.kickoff_at.past?
+    first_game.kickoff_at.past?
   end
 
   def self.before_last_kickoff?
-    LAST_GAME.kickoff_at.future?
+    last_game.kickoff_at.future?
   end
 
   def self.after_last_kickoff?
-    LAST_GAME.kickoff_at.past?
+    last_game.kickoff_at.past?
   end
 
   def self.tournament_ongoing?
     after_first_kickoff? && before_last_kickoff?
+  end
+
+  def self.after_last_final_whistle?
+    last_game.final_whistle?
   end
 
   def self.after_group_phase?

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -336,6 +336,13 @@ de-CH:
       header:
         one: 'Konnte %{model} nicht speichern: ein Fehler.'
         other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
+  final_ranking_component:
+    congratulations_to_our_global_winners:
+      one: Gratulation an den/die globalen Gewinner:in
+      other: Gratulationen an die globalen Gewinner
+    they_deserve_title_html:
+      one: Er/sie verdient es von nun an mit <b>FUSSBALLÜBERGOTT</b> angesprochen zu werden.
+      other: Sie verdienen es von nun an mit <b>FUSSBALLÜBERGOTT</b> angesprochen zu werden.
   game_stats_component:
     bets_by_scores: Nach Torstand
   helpers:
@@ -514,6 +521,9 @@ de-CH:
     loading: Lade
     members: Mitglieder
     meta_description: Gratis online Tippspiel für die UEFA Euro 2020.
+    n_points:
+      one: "%{count} Punkt"
+      other: "%{count} Punkte"
     new_password: Neues Passwort
     no_one_with_brackets: "(niemanden)"
     odds: Wettquote
@@ -529,6 +539,7 @@ de-CH:
     teams: Teams
     tournament: Turnier
     uefa_game_id: Spiel %{uefa_game_id}
+    your_final_global_ranking: Dein globaler Schlussrang
     your_rank: Dein Rang
     your_ranking_in_this_team: Dein Rang in diesem Team
   support:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,6 +336,13 @@ en:
       header:
         one: 1 error prohibited this %{model} from being saved
         other: "%{count} errors prohibited this %{model} from being saved"
+  final_ranking_component:
+    congratulations_to_our_global_winners:
+      one: Congratulations to our global winner
+      other: Congratulations to our global winners
+    they_deserve_title_html:
+      one: They deserve to be addressed with <b>FUSSBALLÜBERGOTT</b> from now on.
+      other: They deserve to be addressed with <b>FUSSBALLÜBERGOTT</b> from now on.
   game_stats_component:
     bets_by_scores: Bets by scores
   helpers:
@@ -506,6 +513,9 @@ en:
     loading: Loading
     members: Members
     meta_description: Free online betting game for UEFA Euro 2020.
+    n_points:
+      one: "%{count} point"
+      other: "%{count} points"
     new_password: New password
     no_one_with_brackets: "(no one)"
     odds: Odds
@@ -521,6 +531,7 @@ en:
     teams: Teams
     tournament: Tournament
     uefa_game_id: Match %{uefa_game_id}
+    your_final_global_ranking: Your final global ranking
     your_rank: Your rank
     your_ranking_in_this_team: Your ranking in this team
   support:

--- a/test/components/current_ranking_component_test.rb
+++ b/test/components/current_ranking_component_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class CurrentRankingComponentTest < ViewComponent::TestCase
+  test '.render, in_game_1' do
+    user = users(:diego)
+    Game.update_all(final_whistle_at: nil)
+
+    in_game_1 do
+      FinalWhistleService.new.call!
+      user.reload
+      render_inline DashboardRankingComponent.new(user)
+      assert_selector '.points', text: '0', exact_text: true
+      assert_selector '.global-ranking', text: '1', exact_text: true
+    end
+  end
+
+  test '.render, during tournament' do
+    before_game_25 do
+      component = DashboardRankingComponent.new(users(:diego))
+
+      render_inline(component)
+      assert_selector '.points', text: '152'
+      assert_selector '.global-ranking', text: '1', exact_text: true
+
+      assert_link 'Global ranking', href: '/teams/global'
+    end
+  end
+end

--- a/test/components/dashboard_ranking_component_test.rb
+++ b/test/components/dashboard_ranking_component_test.rb
@@ -8,28 +8,21 @@ class DashboardRankingComponentTest < ViewComponent::TestCase
     end
   end
 
-  test '.render, in_game_1' do
-    user = users(:diego)
-    Game.update_all(final_whistle_at: nil)
-
+  test '.render, before last final whistle' do
     in_game_1 do
-      FinalWhistleService.new.call!
-      user.reload
-      render_inline DashboardRankingComponent.new(user)
-      assert_selector '.points', text: '0', exact_text: true
-      assert_selector '.global-ranking', text: '1', exact_text: true
+      render_inline DashboardRankingComponent.new(users(:diego))
+      assert_selector '.points', text: '152'
+      assert_selector '.global-ranking', text: '1'
     end
   end
 
-  test '.render, during tournament' do
-    before_game_25 do
-      component = DashboardRankingComponent.new(users(:diego))
+  test '.render, after last final whistle' do
+    end_tournament!
 
-      render_inline(component)
-      assert_selector '.points', text: '152'
-      assert_selector '.global-ranking', text: '1', exact_text: true
-
-      assert_link 'Global ranking', href: '/teams/global'
+    after_tournament do
+      render_inline DashboardRankingComponent.new(users(:diego))
+      assert_text 'Your final global ranking'
+      assert_text '1'
     end
   end
 end

--- a/test/components/final_ranking_component_test.rb
+++ b/test/components/final_ranking_component_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class FinalRankingComponentTest < ViewComponent::TestCase
+  test '.render, one winner' do
+    end_tournament!
+
+    component = FinalRankingComponent.new(users(:diego))
+    render_inline component
+
+    assert_equal 1, component.global_winners.count
+    assert_includes component.global_winners, users(:diego)
+
+    assert_text 'Your final global ranking'
+    assert_selector '.global-ranking', text: '1'
+
+    assert_text 'Congratulations to our global winner'
+    assert_selector 'li', count: 1
+    assert_selector 'li', text: 'digi'
+    assert_text 'They deserve to be addressed with FUSSBALLÜBERGOTT from now on.'
+
+    assert_link 'Global ranking', href: '/teams/global'
+  end
+
+  test '.render, multiple winners' do
+    end_tournament!
+
+    memberships(:zinedine_global).update_column(:ranking_position, 1)
+
+    component = FinalRankingComponent.new(users(:diego))
+    render_inline component
+
+    assert_equal 2, component.global_winners.count
+    assert_includes component.global_winners, users(:diego)
+    assert_includes component.global_winners, users(:zinedine)
+
+    assert_text 'Congratulations to our global winners'
+    assert_selector 'li', count: 2
+    assert_selector 'li', text: 'digi'
+    assert_selector 'li', text: 'zinedine'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,12 @@ class ActiveSupport::TestCase
   def reset_bet(bet)
     bet.update_columns(home_team_score: nil, guest_team_score: nil)
   end
+
+  def end_tournament!
+    Tournament.last_game.tap do |last_game|
+      last_game.update!(final_whistle_at: last_game.kickoff_at + 105.minutes)
+    end
+  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/time_travelers.rb
+++ b/test/time_travelers.rb
@@ -36,6 +36,6 @@ module TimeTravelers
   end
 
   def after_tournament(&block)
-    travel_to('2021-07-11 20:00:00 UTC', &block)
+    travel_to('2021-07-11 21:00:00 UTC', &block)
   end
 end


### PR DESCRIPTION
DashboardRankingComponent is split into two new components:

* CurrentRankingComponent which is rendered until the tournament ends
* FinalRankingComponennt which is rendered after the tournament ends

FinalRankingComponent shows credits to the global winners.